### PR TITLE
Find refund payments by number

### DIFF
--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class RefundsController < ResourceController
-      belongs_to 'spree/payment'
+      belongs_to 'spree/payment', find_by: :number
       before_action :load_order
 
       helper_method :refund_reasons


### PR DESCRIPTION
The payments need to be find by number.
We where not able to created refunds of a payment because the payment where find by id (default).