### PR TITLE
Improved order promotions view and promotions model

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -19,7 +19,7 @@ module Spree
         total_promotions_computable = 0
 
         Spree::Promotion.backend.active.each do |promotion|
-          if promotion.active && promotion.class.order_activatable?(@order)
+          if promotion.class.order_activatable?(@order)
             available_promotions_actions += promotion.promotion_actions
           end
         end

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -15,20 +15,13 @@ module Spree
         # but we need to communicate to the user if there are any active
         # promotions to apply to the order.
 
-        available_promotions_actions = []
-        total_promotions_computable = 0
-
-        Spree::Promotion.backend.active.each do |promotion|
-          if promotion.class.order_activatable?(@order)
-            available_promotions_actions += promotion.promotion_actions
-          end
-        end
-
-        available_promotions_actions.each do |action|
-          @order.line_items.map{ |i| total_promotions_computable += action.compute(i) }
-        end if available_promotions_actions.any?
-
-        @available_promotions = total_promotions_computable > 0 ? true : false
+        @available_promotions = Spree::Promotion
+          .backend
+          .active
+          .flat_map { |promo| promo.promotion_actions if promo.class.order_activatable?(@order) }
+          .compact
+          .map { |action| @order.line_items.map { |i| action.compute(i) }.sum }
+          .sum > 0
       end
 
       def apply_to_order

--- a/backend/app/views/spree/admin/promotions/order_promotions.html.erb
+++ b/backend/app/views/spree/admin/promotions/order_promotions.html.erb
@@ -5,27 +5,33 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to(Spree.t(:add_promotion), "javascript:;", class: "btn-success", data: { toggle: "modal", target: "#addPromotion" }, icon: 'add') if can? :create, Spree::Promotion %>
-<% end %>
+  <%= button_link_to(Spree.t(:add_promotion), "javascript:;", class: "btn-success", data: { toggle: "modal", target: "#addPromotion" }, icon: 'add') %>
+<% end if can?(:create, Spree::Promotion) && @available_promotions %>
 
-<div class="modal fade" id="addPromotion" tabindex="-1" role="dialog" aria-labelledby="addPromotionLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="addPromotionLabel"><%= Spree.t(:add_promotion) %></h4>
-      </div>
-      <div class="modal-body">
-        <%= form_tag admin_order_apply_promotion_path(@order), method: "POST" do %>
-          <div class="form-group">
-            <%= select_tag :promotion_id, options_from_collection_for_select(Spree::Promotion.backend.all, :id, :name), class: 'select2' %>
-          </div>
-          <%= button Spree.t('actions.add'), 'ok', 'submit', { class: 'btn-success' } %>
-        <% end %>
+<% if @available_promotions %>
+  <div class="modal fade" id="addPromotion" tabindex="-1" role="dialog" aria-labelledby="addPromotionLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="addPromotionLabel"><%= Spree.t(:add_promotion) %></h4>
+        </div>
+        <div class="modal-body">
+          <%= form_tag admin_order_apply_promotion_path(@order), method: "POST" do %>
+            <div class="form-group">
+              <%= select_tag :promotion_id, options_from_collection_for_select(Spree::Promotion.backend.active.all, :id, :name), class: 'select2' %>
+            </div>
+            <%= button Spree.t('actions.add'), 'ok', 'submit', { class: 'btn-success' } %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% else %>
+  <div class="alert alert-warning">
+    There are no available backend promotions which can be applied to this order.
+  </div>
+<% end %>
 
 <% if @promotions.any? %>
   <table class="table">

--- a/backend/app/views/spree/admin/promotions/order_promotions.html.erb
+++ b/backend/app/views/spree/admin/promotions/order_promotions.html.erb
@@ -29,7 +29,7 @@
   </div>
 <% else %>
   <div class="alert alert-warning">
-    There are no available backend promotions which can be applied to this order.
+    <%= Spree.t(:there_are_no_available_backend_promotions_which_can_be_applied_to_this_order) %>
   </div>
 <% end %>
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -1,7 +1,7 @@
 module Spree
   class Promotion < Spree::Base
     MATCH_POLICIES = %w(all any)
-    UNACTIVATABLE_ORDER_STATES = ["complete", "awaiting_return", "returned"]
+    UNACTIVATABLE_ORDER_STATES = ["awaiting_return", "returned"]
     BACKEND_PROMOTIONS = ["backend"]
 
     attr_reader :eligibility_errors


### PR DESCRIPTION
We had to improve the order promotions page. It was very unclear if you could apply promotions and if promotions where applied. So we now only let a user apply a promotion if it is able to.

We deleted the complete state from the UNACTIVATABLE_ORDER_STATES constant because in the admin we apply promotions to complete orders (Price Match)