### PR TITLE
Give option to select ‘given to customer’ or ‘lost in transit’ when p…

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -7,9 +7,14 @@
       <th><%= Spree.t(:preferred_reimbursement_type) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:acceptance_errors) %></th>
-      <% if show_decision %>
-        <th></th>
+      <th><%= Spree.t(:reception_status) %></th>
+      <% unless return_items.all?(&:received?)%>
+        <th><%= Spree.t(:item_received?) %></th>
       <% end %>
+       <% if show_decision %>
+        <th></th>
+        <th class="actions"></th>
+       <% end %>
     </tr>
   </thead>
   <tbody>
@@ -22,26 +27,39 @@
         <td>
           <%= return_item.inventory_unit.variant.sku %>
         </td>
-        <td>
+        <td class="align-center">
           <%= return_item.display_pre_tax_amount %>
         </td>
-        <td>
+        <td class="align-center">
           <%= reimbursement_type_name(return_item.preferred_reimbursement_type) %>
         </td>
-        <td>
-          <%= return_item.exchange_variant.try(:exchange_name) %>
+        <td class="align-center">
+          <%= return_item.exchange_variant.try(:options_text) %>
         </td>
-        <td>
+        <td class="align-center">
           <%= return_item.acceptance_status_errors %>
         </td>
+        <td class-"align-center">
+          <%= return_item.reception_status.humanize %>
+        </td>
+        <% unless return_item.received? %>
+          <td class='align-center'>
+            <%= form_for [:admin, return_item] do |f| %>
+              <%= f.hidden_field 'reception_status_event', value: 'receive' %>
+              <%= f.button Spree.t(:receive), class: 'fa icon_link no-text with-tip', "data-action" => 'save' %>
+            <% end %>
+          </td>
+        <% end %>
         <% if show_decision %>
           <td class="actions forms-inline">
-            <%= button_to [:admin, return_item], { class: 'with-tip display-inline btn btn-success btn-sm', params: { "return_item[acceptance_status]" => 'accepted' }, "data-action" => 'save', title: Spree.t(:accept), method: 'put' } do %>
-              <%= Spree.t(:accept) %>
-            <% end if can?(:accept, return_item) %>
-            <%= button_to [:admin, return_item], { class: 'with-tip display-inline btn btn-danger btn-sm', params: { "return_item[acceptance_status]" => 'rejected' }, "data-action" => 'remove', title: Spree.t(:reject), method: 'put' } do %>
-              <%= Spree.t(:reject) %>
-            <% end if can?(:reject, return_item) %>
+            <%= form_for [:admin, return_item] do |f| %>
+              <%= f.hidden_field 'acceptance_status', value: 'accepted' %>
+              <%= f.button Spree.t(:accept), class: 'fa fa-thumbs-up icon_link no-text with-tip', title: Spree.t(:accept), "data-action" => 'save' %>
+            <% end %>
+            <%= form_for [:admin, return_item] do |f| %>
+              <%= f.hidden_field 'acceptance_status', value: 'rejected' %>
+              <%= f.button Spree.t(:reject), class: 'fa fa-thumbs-down icon_link no-text with-tip', title: Spree.t(:reject), "data-action" => 'remove' %>
+            <% end %>
           </td>
         <% end %>
       </tr>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -9,6 +9,7 @@
       <th><%= Spree.t(:pre_tax_amount) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:resellable) %></th>
+      <th><%= Spree.t(:reception_status) %></th>
     </tr>
   </thead>
   <tbody>
@@ -34,10 +35,13 @@
           <%= return_item.display_pre_tax_amount %>
         </td>
         <td class="align-center">
-          <%= return_item.exchange_variant.try(:exchange_name) %>
+          <%= return_item.exchange_variant.try(:options_text) %>
         </td>
         <td class="align-center">
           <%= item_fields.check_box :resellable, { checked: return_item.resellable } %>
+        </td>
+        <td class="align-center">
+          <%= item_fields.select :reception_status_event, return_item.available_active_status_paths, {include_blank: false}, {class: 'add-item select2 fullwidth'} %>
         </td>
       </tr>
     <% end %>

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -166,7 +166,8 @@ module Spree
                   "0" => {
                     returned: "1",
                     "pre_tax_amount"=>"15.99",
-                    inventory_unit_id: order.inventory_units.shipped.last.id
+                    inventory_unit_id: order.inventory_units.shipped.last.id,
+                    reception: 'receive'
                   }
                 }
               }
@@ -193,7 +194,8 @@ module Spree
                   "0" => {
                     returned: "1",
                     "pre_tax_amount"=>"15.99",
-                    inventory_unit_id: order.inventory_units.shipped.last.id
+                    inventory_unit_id: order.inventory_units.shipped.last.id,
+                    reception: 'receive'
                   }
                 }
               }

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -12,6 +12,7 @@ describe Spree::Admin::ReimbursementsController, :type => :controller do
     let(:order) { customer_return.order }
     let(:return_item) { customer_return.return_items.first }
     let(:payment) { order.payments.first }
+    before { return_item.receive! }
 
     subject do
       spree_post :create, order_id: order.to_param, build_from_customer_return_id: customer_return.id

--- a/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::ReturnItemsController, :type => :controller do
   describe '#update' do
     let(:customer_return) { create(:customer_return) }
     let(:return_item) { customer_return.return_items.first }
-    let(:old_acceptance_status) { 'accepted' }
+    let(:old_acceptance_status) { 'pending' }
     let(:new_acceptance_status) { 'rejected' }
 
     subject do

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -50,7 +50,6 @@ module Spree
     end
 
     def process_return!
-      return_items.each(&:receive!)
       order.return! if order.all_inventory_units_returned?
     end
 

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -1,6 +1,7 @@
 module Spree
   class ReturnItem < Spree::Base
-    COMPLETED_RECEPTION_STATUSES = %w(received given_to_customer)
+
+    COMPLETED_RECEPTION_STATUSES = %i(received given_to_customer lost_in_transit)
 
     class_attribute :return_eligibility_validator
     self.return_eligibility_validator = ReturnItem::EligibilityValidator::Default
@@ -31,6 +32,9 @@ module Spree
     scope :awaiting_return, -> { where(reception_status: 'awaiting') }
     scope :received, -> { where(reception_status: 'received') }
     scope :not_cancelled, -> { where.not(reception_status: 'cancelled') }
+    scope :given_to_customer, -> { where(reception_status: 'given_to_customer') }
+    scope :lost_in_transit, -> { where(reception_status: 'lost_in_transit') }
+    scope :received, -> { where(reception_status: 'received') }
     scope :pending, -> { where(acceptance_status: 'pending') }
     scope :accepted, -> { where(acceptance_status: 'accepted') }
     scope :rejected, -> { where(acceptance_status: 'rejected') }
@@ -54,11 +58,11 @@ module Spree
     before_save :set_exchange_pre_tax_amount
 
     state_machine :reception_status, initial: :awaiting do
-      after_transition to: :received, do: :attempt_accept
+      after_transition to: COMPLETED_RECEPTION_STATUSES,  do: :attempt_accept
       after_transition to: :received, do: :process_inventory_unit!
 
       event :receive do
-        transition to: :received, from: :awaiting
+        transition to: :received, from: [:awaiting, :given_to_customer, :lost_in_transit]
       end
 
       event :cancel do
@@ -67,6 +71,10 @@ module Spree
 
       event :give do
         transition to: :given_to_customer, from: :awaiting
+      end
+
+      event :lost do
+        transition to: :lost_in_transit, from: :awaiting
       end
     end
 
@@ -145,6 +153,14 @@ module Spree
       self.pre_tax_amount = refund_amount_calculator.new.compute(self)
     end
 
+    def available_active_status_paths
+      status_paths = reception_status_paths.to_states
+      event_paths = reception_status_paths.events
+      status_paths.delete(:cancelled)
+      event_paths.delete(:cancel)
+      status_paths.map{ |s| s.to_s.humanize }.zip(event_paths)
+    end
+
     private
 
     def persist_acceptance_status_errors
@@ -168,6 +184,7 @@ module Spree
       inventory_unit.return!
 
       Spree::StockMovement.create!(stock_item_id: stock_item.id, quantity: 1) if should_restock?
+      customer_return.process_return! if customer_return
     end
 
     # This logic is also present in the customer return. The reason for the

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -189,7 +189,7 @@ module Spree
       inventory_unit.return!
 
       Spree::StockMovement.create!(stock_item_id: stock_item.id, quantity: 1) if should_restock?
-      customer_return.process_return! if customer_return
+      customer_return.send(:process_return!) if customer_return
     end
 
     # This logic is also present in the customer return. The reason for the

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -79,7 +79,7 @@ module Spree
       end
 
       event :oos do
-        transition to: :out_of_stock, from :awaiting
+        transition to: :out_of_stock, from: :awaiting
       end
     end
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -40,7 +40,7 @@ module Spree
       :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
     ]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -176,6 +176,7 @@ describe Spree::Reimbursement, type: :model do
   describe '.build_from_customer_return' do
     let(:customer_return) { create(:customer_return, line_items_count: 5) }
 
+    before { customer_return.return_items.each(&:receive!) }
     let!(:pending_return_item) { customer_return.return_items.first.tap { |ri| ri.update!(acceptance_status: 'pending') } }
     let!(:accepted_return_item) { customer_return.return_items.second.tap(&:accept!) }
     let!(:rejected_return_item) { customer_return.return_items.third.tap(&:reject!) }

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -19,7 +19,9 @@ describe Spree::ReturnItem, :type => :model do
 
   describe '#receive!' do
     let(:now)            { Time.now }
-    let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
+    let(:order)          { create(:shipped_order)}
+    let(:inventory_unit) { create(:inventory_unit, order: order,state: 'shipped') }
+    let!(:customer_return) { create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id) }
     let(:return_item)    { create(:return_item, inventory_unit: inventory_unit) }
 
     before do
@@ -29,7 +31,6 @@ describe Spree::ReturnItem, :type => :model do
     end
 
     subject { return_item.receive! }
-
 
     it 'returns the inventory unit' do
       subject
@@ -43,7 +44,6 @@ describe Spree::ReturnItem, :type => :model do
 
     context 'with a stock location' do
       let(:stock_item)      { inventory_unit.find_stock_item }
-      let!(:customer_return) { create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id) }
 
       before do
         inventory_unit.update_attributes!(state: 'shipped')
@@ -79,6 +79,34 @@ describe Spree::ReturnItem, :type => :model do
         it 'does not increase the count on hand' do
           expect { subject }.to_not change { stock_item.reload.count_on_hand }
         end
+      end
+    end
+
+    context 'when the item was given to customer' do
+      before { return_item.update_attributes!(reception_status: 'given_to_customer') }
+
+      it 'processes the inventory unit' do
+        subject
+        expect(return_item.inventory_unit.reload.state).to eq('returned')
+      end
+
+      it 'return remains accepted' do
+        subject
+        expect(return_item.acceptance_status).to eq('accepted')
+      end
+    end
+
+    context 'when the item was lost in transit' do
+      before { return_item.update_attributes!(reception_status: 'lost_in_transit') }
+
+      it 'processes the inventory unit' do
+        subject
+        expect(return_item.inventory_unit.reload.state).to eq('returned')
+      end
+
+      it 'return remains accepted' do
+        subject
+        expect(return_item.acceptance_status).to eq('accepted')
       end
     end
   end
@@ -177,10 +205,8 @@ describe Spree::ReturnItem, :type => :model do
       end
     end
 
-    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
-      context "return_item has a reception status of #{invalid_transition_status}" do
-        it_behaves_like "an invalid state transition", invalid_transition_status, 'received'
-      end
+    context "return_item has a reception status of cancelled" do
+      it_behaves_like "an invalid state transition", 'cancelled', 'received'
     end
   end
 
@@ -207,25 +233,77 @@ describe Spree::ReturnItem, :type => :model do
   end
 
   describe "#give" do
-    let(:return_item) { create(:return_item, reception_status: status) }
+    let(:return_item) { create(:return_item, reception_status: 'given_to_customer', inventory_unit: inventory_unit) }
+    let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
+
 
     subject { return_item.give! }
 
     context "awaiting status" do
-      let(:status) { 'awaiting' }
+      before do
+        inventory_unit.update_attributes!(state: 'shipped')
+        return_item.update_attributes!(reception_status: 'awaiting')
+        return_item.stub(:eligible_for_return?).and_return(true)
+      end
 
-      before { subject }
+      it "attempts to accept the return" do
+        expect(return_item).to receive(:attempt_accept)
+        subject
+      end
+
+      it 'accepts the return' do
+        subject
+        expect(return_item.acceptance_status).to eq('accepted')
+      end
+
+      it 'does not decrease inventory' do
+        subject
+        expect(return_item).to_not receive(:process_inventory_unit)
+      end
 
       it "transitions successfully" do
+        subject
         expect(return_item).to be_given_to_customer
       end
     end
 
-    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
-      context "return_item has a reception status of #{invalid_transition_status}" do
-        it_behaves_like "an invalid state transition", invalid_transition_status, 'give_to_customer'
+    it_behaves_like "an invalid state transition", 'cancelled', 'given_to_customer'
+  end
+
+  describe "#give" do
+    let(:return_item) { create(:return_item, reception_status: 'lost_in_transit', inventory_unit: inventory_unit) }
+    let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
+
+    subject { return_item.lost! }
+
+    context "awaiting status" do
+      before do
+        return_item.update_attributes!(reception_status: 'awaiting')
+        return_item.stub(:eligible_for_return?).and_return(true)
+      end
+
+      it "attempts to accept the return" do
+        expect(return_item).to receive(:attempt_accept)
+        subject
+      end
+
+      it 'accepts the return' do
+        subject
+        expect(return_item.acceptance_status).to eq('accepted')
+      end
+
+      it 'does not decrease inventory' do
+        subject
+        expect(return_item).to_not receive(:process_inventory_unit)
+      end
+
+      it "transitions successfully" do
+        subject
+        expect(return_item).to be_lost_in_transit
       end
     end
+
+    it_behaves_like "an invalid state transition", 'cancelled', 'given_to_customer'
   end
 
   describe "#attempt_accept" do

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -243,7 +243,7 @@ describe Spree::ReturnItem, :type => :model do
       before do
         inventory_unit.update_attributes!(state: 'shipped')
         return_item.update_attributes!(reception_status: 'awaiting')
-        return_item.stub(:eligible_for_return?).and_return(true)
+        allow(return_item).to receive(:eligible_for_return?).and_return(true)
       end
 
       it "attempts to accept the return" do
@@ -279,7 +279,7 @@ describe Spree::ReturnItem, :type => :model do
     context "awaiting status" do
       before do
         return_item.update_attributes!(reception_status: 'awaiting')
-        return_item.stub(:eligible_for_return?).and_return(true)
+        allow(return_item).to receive(:eligible_for_return?).and_return(true)
       end
 
       it "attempts to accept the return" do
@@ -311,12 +311,12 @@ describe Spree::ReturnItem, :type => :model do
     let(:return_item) { create(:return_item, reception_status: 'out_of_stock', inventory_unit: inventory_unit) }
     let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
 
-    subject { return_item.lost! }
+    subject { return_item.oos! }
 
     context "awaiting status" do
       before do
         return_item.update_attributes!(reception_status: 'awaiting')
-        return_item.stub(:eligible_for_return?).and_return(true)
+        allow(return_item).to receive(:eligible_for_return?).and_return(true)
       end
 
       it "attempts to accept the return" do

--- a/core/spec/support/mock_model_patch.rb
+++ b/core/spec/support/mock_model_patch.rb
@@ -1,0 +1,9 @@
+require_dependency 'rspec/active_model/mocks/mocks'
+
+module RspecMocksPatch
+  extend ActiveSupport::Concern
+
+  included { alias_method :_read_attribute, :[] }
+end
+
+RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.include(RspecMocksPatch)


### PR DESCRIPTION
…rocessing customer returns

Hand picked cherry-pick of those two commits:
https://github.com/bonobos/spree/commit/7fcd0736a0824a8fe1f046b23627a2fbd7bd22af?diff=unified
https://github.com/bonobos/spree/commit/86551ecdb2ebfcb655112749cc944c7febc9468f

Added two new states to return items (given, lost) as a completed state; if a return item is given or lost, the inventory unit is not changed. An item can go from lost or given to received, which will update inventory. Backend customer return view now requires a choice selected determining the reception status.
