### PR TITLE
Locked dependency state_machines-activerecord to 0.2

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2.0'
   s.add_dependency 'ransack', '~> 1.4.1'
   s.add_dependency 'responders'
-  s.add_dependency 'state_machines-activerecord', '~> 0.2'
+  s.add_dependency 'state_machines-activerecord', '0.2'
   s.add_dependency 'stringex'
   s.add_dependency 'truncate_html', '0.9.2'
   s.add_dependency 'twitter_cldr', '~> 3.0'


### PR DESCRIPTION
When running bundle update spree, state_machines-activerecord get updated to 0.3 where all kinds of specs fail.. lock it to 0.2 to prevent this.