### PR TITLE
Changed syntax of customer returns scope

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -23,7 +23,7 @@ module Spree
     }
 
     scope :with_pending_reimbursements, -> {
-      joins(:reimbursements).where('spree_reimbursements.reimbursement_status': 'pending')
+      joins(:reimbursements).where(:'spree_reimbursements.reimbursement_status' => 'pending')
     }
 
     def pre_tax_total


### PR DESCRIPTION
```syntax error, unexpected ':', expecting ')' (SyntaxError)
...rsements.reimbursement_status': 'pending')```

Tests wouldnt run with the old syntax