### PR TITLE
Specify product properties by pre-defined property

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -226,9 +226,13 @@ $(document).ready(function(){
   });
 
   var uniqueId = 1;
-  $('.spree_add_fields').click(function() {
+  $('body').on('click', '.spree_add_fields', function() {
     var target = $(this).data("target");
-    var new_table_row = $(target + ' tr:visible:last').clone();
+    var $target_tr = $(target + ' tr:visible:last');
+
+    // if we clone a select 2, destroy it first, we enable it later
+    $('select.select2', $target_tr).select2("destroy");
+    var new_table_row = $target_tr.clone();
     var new_id = new Date().getTime() + (uniqueId++);
     new_table_row.find("input, select").each(function () {
       var el = $(this);
@@ -236,15 +240,22 @@ $(document).ready(function(){
       el.prop("id", el.prop("id").replace(/\d+/, new_id))
       el.prop("name", el.prop("name").replace(/\d+/, new_id))
     })
-    // When cloning a new row, set the href of all icons to be an empty "#"
-    // This is so that clicking on them does not perform the actions for the
-    // duplicated row
-    new_table_row.find("a").each(function () {
-      var el = $(this);
-      el.prop('href', '#');
-    })
+    // When cloning a new row, remove all buttons, the actions dont
+    // work so why display them
+    new_table_row.find("a.btn").each(function () {
+      $(this).remove();
+    });
+    new_table_row.find("select.select2").each(function () {
+      // enable the select 2 in the new row
+      // set the first value by default
+      $(this).select2().select2('val', $('option:eq(0)', $(this)).val());
+    });
+    // re-enable the select 2 of the original tr
+    if($('select.select2', $target_tr).length){
+      $('select.select2', $target_tr).select2();
+    }
     $(target).prepend(new_table_row);
-  })
+  });
 
   $('body').on('click', '.delete-resource', function() {
     var el = $(this);

--- a/backend/app/controllers/spree/admin/product_properties_controller.rb
+++ b/backend/app/controllers/spree/admin/product_properties_controller.rb
@@ -1,17 +1,18 @@
 module Spree
   module Admin
     class ProductPropertiesController < ResourceController
-      belongs_to 'spree/product', :find_by => :slug
+      belongs_to 'spree/product', find_by: :slug
       before_action :find_properties
       before_action :setup_property, only: :index
 
       private
-        def find_properties
-          @properties = Spree::Property.pluck(:name)
-        end
 
         def setup_property
-          @product.product_properties.build
+          @product.product_properties.build if !@product.product_properties.any?
+        end
+
+        def find_properties
+          @properties = Spree::Property.all
         end
     end
   end

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -5,7 +5,6 @@ module Spree
 
       before_action :load_data, except: :index
       create.before :create_before
-      update.before :update_before
       helper_method :clone_object_url
 
       def show
@@ -83,7 +82,7 @@ module Spree
       end
 
       def location_after_save
-        spree.edit_admin_product_url(@product)
+        :back
       end
 
       def load_data
@@ -117,13 +116,6 @@ module Spree
       def create_before
         return if params[:product][:prototype_id].blank?
         @prototype = Spree::Prototype.find(params[:product][:prototype_id])
-      end
-
-      def update_before
-        # note: we only reset the product properties if we're receiving a post
-        #       from the form on that tab
-        return unless params[:clear_product_properties]
-        params[:product] ||= {}
       end
 
       def product_includes

--- a/backend/app/views/spree/admin/product_properties/_product_property_fields.html.erb
+++ b/backend/app/views/spree/admin/product_properties/_product_property_fields.html.erb
@@ -1,17 +1,17 @@
 <tr class="product_property fields" id="spree_<%= dom_id(f.object) %>" data-hook="product_property">
-  <td>
+  <td width="14">
     <% if f.object.persisted? && can?(:edit, f.object) %>
       <span class="icon icon-move js-sort-handle"></span>
-      <%= f.hidden_field :id %>
     <% end %>
+    <%= f.hidden_field :id %>
   </td>
   <td class='property_name'>
-    <%= f.text_field :property_name, class: 'autocomplete form-control' %>
+    <%= f.select :property_id, @properties.map { |p| [p.name, p.id] }, {}, { selected: (f.object.property ? f.object.property.id : nil), class: "select2" } %>
   </td>
   <td class='value'>
     <%= f.text_field :value, class: 'form-control' %>
   </td>
-  <td class="actions actions-1">
+  <td class="actions" width="100">
     <% if f.object.persisted? && can?(:destroy, f.object) %>
       <%= link_to_delete f.object, no_text: true %>
     <% end %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -1,12 +1,17 @@
-<%= render 'spree/admin/shared/product_tabs', :current => 'Product Properties' %>
-<%= render 'spree/admin/shared/error_messages', :target => @product %>
+<%= render 'spree/admin/shared/product_tabs', current: 'Product Properties' %>
+<%= render 'spree/admin/shared/error_messages', target: @product %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to(Spree.t(:add_product_properties), "javascript:;", { :icon => 'add', :'data-target' => "tbody#product_properties", :class => 'btn-success spree_add_fields' }) %>
-  <span class="js-new-ptype-link"><%= button_link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, { :icon => 'properties', :remote => true, 'data-update' => 'prototypes', :class => 'btn-default' } %></span>
+  <%= button_link_to Spree.t(:add_property), "javascript:;", { icon: 'add', data: { target: 'tbody#product_properties' }, class: 'btn-success spree_add_fields' } %>
+
+  <% if Spree::Prototype.any? %>
+    <span class="js-new-ptype-link">
+      <%= button_link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, { icon: 'properties', remote: true, data: { update: 'prototypes' }, class: 'btn-default' } %>
+    </span>
+  <% end %>
 <% end if can? :create, Spree::ProductProperty %>
 
-<%= form_for @product, :url => spree.admin_product_url(@product), :method => :put do |f| %>
+<%= form_for @product, url: spree.admin_product_url(@product), method: :put do |f| %>
   <fieldset>
     <div id="prototypes" data-hook></div>
 
@@ -20,24 +25,11 @@
       </thead>
       <tbody id="product_properties" data-hook>
         <%= f.fields_for :product_properties do |pp_form| %>
-          <%= render 'product_property_fields', :f => pp_form %>
+          <%= render 'product_property_fields', f: pp_form %>
         <% end %>
       </tbody>
     </table>
 
     <%= render('spree/admin/shared/edit_resource_links') if can? :update, Spree::ProductProperty %>
-
-    <%= hidden_field_tag 'clear_product_properties', 'true' %>
   </fieldset>
-<% end %>
-
-<%= javascript_tag do %>
-  var properties = <%= raw(@properties.to_json) %>;
-  $('#product_properties').on('keydown', 'input.autocomplete', function() {
-    already_auto_completed = $(this).is('ac_input');
-    if (!already_auto_completed) {
-      $(this).autocomplete({source: properties});
-      $(this).focus();
-    }
-  });
 <% end %>

--- a/backend/app/views/spree/admin/products/_properties_form.erb
+++ b/backend/app/views/spree/admin/products/_properties_form.erb
@@ -3,8 +3,8 @@
 <% end %>
 
 <% f.fields_for :product_properties do |properties_form| %>
-    <div data-hook="value">
-      <%= properties_form.label :value, properties_form.object.property.presentation %>
-      <%= properties_form.text_field :value, :class => "form-control" %>
-    </div>
+  <div data-hook="value">
+    <%= properties_form.label :value, properties_form.object.property.presentation %>
+    <%= properties_form.text_field :value, class: 'form-control' %>
+  </div>
 <% end %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -3,27 +3,27 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_property), new_object_url, { :class => "btn-success", :icon => 'add', 'data-update' => 'new_property', :id => 'new_property_link' } %>
+  <%= button_link_to Spree.t(:new_property), new_object_url, { class: "btn-success", icon: 'add', data: { update: 'new_property' }, id: 'new_property_link' } %>
 <% end %>
 
 <% content_for :table_filter do %>
   <div data-hook="admin_property_sidebar">
     <%= search_form_for [:admin, @search] do |f| %>
 
-      <%- locals = {:f => f} %>
+      <%- locals = {f: f} %>
 
       <div class="row">
         <div class="col col-md-6">
           <div data-hook="admin_property_index_search" class="form-group">
             <%= f.label :name_cont, Spree.t(:name) %>
-            <%= f.text_field :name_cont, :class => "form-control js-quick-search-target" %>
+            <%= f.text_field :name_cont, class: "form-control js-quick-search-target" %>
           </div>
         </div>
 
         <div class="col-md-6">
           <div class="form-group">
             <%= f.label :presentation_cont, Spree.t(:presentation) %>
-            <%= f.text_field :presentation_cont, :class => "form-control" %>
+            <%= f.text_field :presentation_cont, class: "form-control" %>
           </div>
         </div>
       </div>
@@ -51,8 +51,8 @@
           <td><%= property.name %></td>
           <td><%= property.presentation %></td>
           <td class="actions actions-2 text-right">
-            <%= link_to_edit(property, :no_text => true) %>
-            <%= link_to_delete(property, :no_text => true) %>
+            <%= link_to_edit(property, no_text: true) %>
+            <%= link_to_delete(property, no_text: true) %>
           </td>
         </tr>
       <% end %>

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -34,7 +34,7 @@ describe "Properties", type: :feature, js: true do
         click_on "Filter"
         fill_in "q_name_cont", with: "size"
         click_on 'Search'
-        
+
         expect(page).to have_content("shirt size")
         expect(page).not_to have_content("shirt fit")
       end
@@ -78,6 +78,8 @@ describe "Properties", type: :feature, js: true do
   end
 
   context "linking a property to a product" do
+    let!(:property_shirt) { create(:property, name: 'shirt', presentation: 'shirt') }
+
     before do
       create(:product)
       visit spree.admin_products_path
@@ -87,11 +89,12 @@ describe "Properties", type: :feature, js: true do
 
     # Regression test for #2279
     it "successfully create and then remove product property" do
+      # create 3 propertys
       fill_in_property
       # Sometimes the page doesn't load before the all check is done
       # lazily finding the element gives the page 10 seconds
-      expect(page).to have_css("tbody#product_properties tr:nth-child(2)")
-      expect(all("tbody#product_properties tr").count).to eq(2)
+      expect(page).to have_css("tbody#product_properties tr:nth-child(1)")
+      expect(all("tbody#product_properties tr").count).to eq(1)
 
       delete_product_property
 
@@ -102,12 +105,13 @@ describe "Properties", type: :feature, js: true do
     it "successfully remove and create a product property at the same time" do
       fill_in_property
 
-      fill_in "product_product_properties_attributes_1_property_name", with: "New Property"
-      fill_in "product_product_properties_attributes_1_value", with: "New Value"
+      click_link 'Add Property'
+      within_row(1) do
+        find("input.form-control").set "New Value"
+      end
 
       delete_product_property
 
-      # Give fadeOut time to complete
       expect(page).not_to have_selector("#product_product_properties_attributes_0_property_name")
       expect(page).not_to have_selector("#product_product_properties_attributes_0_value")
 
@@ -115,14 +119,12 @@ describe "Properties", type: :feature, js: true do
 
       expect(page).not_to have_content("Product is not found")
 
-      check_property_row_count(2)
+      check_property_row_count(1)
     end
 
     def fill_in_property
-      fill_in "product_product_properties_attributes_0_property_name", with: "A Property"
       fill_in "product_product_properties_attributes_0_value", with: "A Value"
       click_button "Update"
-      click_link "Properties"
     end
 
     def delete_product_property

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -94,7 +94,7 @@ module Spree
 
     attr_accessor :option_values_hash
 
-    accepts_nested_attributes_for :product_properties, allow_destroy: true, reject_if: lambda { |pp| pp[:property_name].blank? }
+    accepts_nested_attributes_for :product_properties, allow_destroy: true
 
     alias :options :product_option_types
 

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -1,9 +1,12 @@
 module Spree
   class ProductProperty < Spree::Base
+    acts_as_list scope: :product
+
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 
     validates :property, presence: true
+    validates :value, presence: true
 
     validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 
@@ -11,16 +14,7 @@ module Spree
 
     # virtual attributes for use with AJAX completion stuff
     def property_name
-      property.name if property
-    end
-
-    def property_name=(name)
-      unless name.blank?
-        unless property = Property.find_by(name: name)
-          property = Property.create(name: name, presentation: name)
-        end
-        self.property = property
-      end
+      property.name
     end
   end
 end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -54,7 +54,7 @@ module Spree
 
     @@payment_attributes = [:amount, :payment_method_id, :payment_method]
 
-    @@product_properties_attributes = [:property_name, :value, :position]
+    @@product_properties_attributes = [:property_id, :value, :position]
 
     @@product_attributes = [
       :name, :description, :available_on, :permalink, :meta_description,

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -54,7 +54,7 @@ module Spree
 
     @@payment_attributes = [:amount, :payment_method_id, :payment_method]
 
-    @@product_properties_attributes = [:property_id, :value, :position]
+    @@product_properties_attributes = [:id, :property_id, :value, :position]
 
     @@product_attributes = [
       :name, :description, :available_on, :permalink, :meta_description,


### PR DESCRIPTION
- you can now only specify product properties by pre defined property's
- so no auto created Spree::Property objects anymore when you create a new ProductProperty.
- you can only select the Property from a dropdown select