### PR TITLE
Fix deadlock in shipping rates table

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -239,7 +239,7 @@ module Spree
     end
 
     def selected_shipping_rate_id=(id)
-      shipping_rates.update_all(selected: false)
+      shipping_rates.unscope(:order).update_all(selected: false)
       shipping_rates.update(id, selected: true)
       self.save!
     end


### PR DESCRIPTION
The scope adds a sort in the update query. With the sort the update needs a filesort in db
```UPDATE `spree_shipping_rates` SET `spree_shipping_rates`.`selected` = 0 WHERE `spree_shipping_rates`.`shipment_id` = 6 ORDER BY cost ASC```

The unscope removes this sort:
```UPDATE `spree_shipping_rates` SET `spree_shipping_rates`.`selected` = 0 WHERE `spree_shipping_rates`.`shipment_id` = 6```