### PR TITLE
Get back run_touch_callbacks

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -75,6 +75,7 @@ module Spree
     after_initialize :ensure_master
 
     after_save :save_master
+    after_save :run_touch_callbacks, if: :anything_changed?
     after_save :reset_nested_changes
 
     before_validation :validate_master
@@ -302,6 +303,10 @@ module Spree
     # ensures the master variant is flagged as such
     def set_master_variant_defaults
       master.is_master = true
+    end
+    
+    def run_touch_callbacks
+      run_callbacks(:touch)
     end
 
     def taxon_and_ancestors


### PR DESCRIPTION
This was removed in previous PR (https://github.com/surfdome/spree/commit/b3ecfdb3ee31339973b40e8d07d7013fea13415b) but surfdome/surfdome specs keep failing without this. This will do nothing, we can remove it later. 